### PR TITLE
Link transport start/stop

### DIFF
--- a/supertonic.lua
+++ b/supertonic.lua
@@ -115,7 +115,7 @@ function startup()
     if params:string("clock_source") == "link" then
       clock.run(
         function()
-          clock.sync(4)
+          clock.sync(params:get("link_quantum"))
           timekeeper:start()
         end
       )

--- a/supertonic.lua
+++ b/supertonic.lua
@@ -111,6 +111,23 @@ function startup()
     end
   end
 
+  function clock.transport.start()
+    if params:string("clock_source") == "link" then
+      clock.run(
+        function()
+          clock.sync(4)
+          timekeeper:start()
+        end
+      )
+    end
+  end
+
+  function clock.transport.stop()
+    if params:string("clock_source") == "link" then
+      timekeeper:stop()
+    end
+  end
+
   startup_done=true
   redraw()
 end
@@ -184,7 +201,11 @@ function key(k,z)
           end
         end)
       else
-        timekeeper:toggle()
+        if params:string("clock_source") ~= "link" then
+          timekeeper:toggle()
+        else
+          print(">>> clock source is Link \n>>> to play, engage transport on another Link'd device with Start/Stop Sync enabled")
+        end
         -- drummer[params:get("selected")]:set_pattern("--------------------------------")
       end
     end


### PR DESCRIPTION
Link has special handling for syncing transport Start/Stop messages, which execute user-definable `clock.transport.start()` and `clock.transport.stop()` messages on norns.

i added these actions, which only apply to Link clocking, which allows a user to press play or stop on a Link'd Bitwig, Live, or iOS app and supertonic will respond! it doesn't seem that there are any affordances for starting a Link transport from norns at the moment, so i've also added a print to the REPL when a user tries to start the transport on supertonic when clocking via Link.

nb. most iOS apps (and Bitwig, it seems?) use a default Link quantum of 4 -- either way, as long as a user matches their `CLOCK > link quantum` to their source, supertonic will sync its transport start on that count.